### PR TITLE
fix: correct critical typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # git-hotfix-inquiro-23-50278-1
-The project demonstration the implimentation of a simple hotfix workflow.
+The project demonstration the implementation of a simple hotfix workflow.


### PR DESCRIPTION
- Changed 'implimentation' to 'implementation'
- This was causing confusion for users